### PR TITLE
silence logs to see tests output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ USER $NB_USER
 
 RUN conda update conda
 RUN conda create --name snakes python=2
-RUN wget http://www.neuron.yale.edu/ftp/neuron/versions/v7.4/nrn-7.4.tar.gz
+RUN wget --no-check-certificate http://www.neuron.yale.edu/ftp/neuron/versions/v7.4/nrn-7.4.tar.gz
 RUN tar xzvf nrn-7.4.tar.gz
 WORKDIR nrn-7.4
 RUN /bin/bash -c "source activate snakes && ./configure --prefix `pwd` --without-iv --with-nrnpython"


### PR DESCRIPTION
@tarelli These couple of changes didn't make it to development on last merged, probably got overwritten when development was merged into casper-tests. They are not needed, it only silences all the logs output during the neuron build, but very useful to see the outcome of the caspers tests without having to open the travis raw log which is very hard to read. 