### PR TITLE
convert netpyne.dict to dict in import --- important for CNS

### DIFF
--- a/netpyne_ui/netpyne_geppetto.py
+++ b/netpyne_ui/netpyne_geppetto.py
@@ -147,7 +147,7 @@ class NetPyNEGeppetto():
             
             # convert fron netpyne.specs.dict to dict
             rule = modelParameters["label"]
-            netParams.cellParams[rule]["conds"] = netParams.cellParams[rule]["conds"].todict()
+            netParams.cellParams[rule] = netParams.cellParams[rule].todict()
 
             return self.getJSONReply()
         except:


### PR DESCRIPTION
### Requires for CNS tutorials 

netpyne module class **specs.dict** behaves different from regular dict components. That create a series of issues when importing cell templates, because the whole rule is changing from regular python dict to netpyne.specs.dict.

After importing, this PR converts back the rule to regular python dict.



@tarelli 