### PR TITLE
fixed installation script if a different branch is defined in the scr…

### DIFF
--- a/utilities/install.py
+++ b/utilities/install.py
@@ -26,10 +26,10 @@ def checkout(folder, default_branch, cwdp):
     os.chdir(newPath)
     python_git=subprocess.Popen("git branch -a",shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE)
     outstd,errstd=python_git.communicate()
-    if branch in str(outstd):
-        subprocess.call(['git', 'checkout', branch], cwd='./')
-    else:
+    if default_branch in str(outstd):
         subprocess.call(['git', 'checkout', default_branch], cwd='./')
+    else:
+        subprocess.call(['git', 'checkout', branch], cwd='./')
     os.chdir(currentPath)
 
 def main(argv):


### PR DESCRIPTION
@adrianq this is to fix the issue we faced the other day, it is a tiny bug in the logic of the checkout we are using at the moment. Make much more sense to swap branch and default_branch the other way around if you guys agree.