### PR TITLE
0.5.2

### DIFF
--- a/netpyne_ui/netpyne_model_interpreter.py
+++ b/netpyne_ui/netpyne_model_interpreter.py
@@ -82,7 +82,7 @@ class NetPyNEModelInterpreter():
 
             # Save the cell position and update elements in defaultValue and size
             populations[cell['tags']['pop']].size = populations[cell['tags']['pop']].size + 1
-            populations[cell['tags']['pop']].defaultValue.elements.append(ArrayElement(index=len(populations[cell['tags']['pop']].defaultValue.elements) , position=Point(x=float(cell['tags']['x']), y=float(cell['tags']['y']), z=float(cell['tags']['z']))))
+            populations[cell['tags']['pop']].defaultValue.elements.append(ArrayElement(index=len(populations[cell['tags']['pop']].defaultValue.elements) , position=Point(x=float(cell['tags']['x']), y=-float(cell['tags']['y']), z=float(cell['tags']['z']))))
             
     def extractInstances(self, netpyne_model, netpyne_geppetto_library, geppetto_model):
         instance = pygeppetto.Variable(id='network')

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ for root, dirnames, filenames in os.walk('src/jupyter_geppetto/geppetto/src/main
 
 setuptools.setup(
     name="netpyne_ui",
-    version="0.5.1",
+    version="0.5.2",
     url="https://github.com/MetaCell/NetPyNE-UI",
     author="MetaCell",
     author_email="info@metacell.us",
@@ -38,6 +38,6 @@ setuptools.setup(
     ],
     install_requires=[
         'jupyter_geppetto==0.4.2',
-        'netpyne==0.9.1'
+        'netpyne==0.9.1.1'
     ],
 )


### PR DESCRIPTION
The bumped NetPyNe version is to account for the bug fix Salvador did on the plot fonts sizes.
The minus sign is untested, it's meant to address: 
```
The y coord is interpreted as depth so a value of 0 means at the top.
In the GUI this is inverted -- lower values appear at the bottom.
This means the models that have eg. layers 2, 4, 5 will appear inverted (e.g. gui_tut3.py)
```