### PR TITLE
#253 Enable eslint to parse ES2020 features

### DIFF
--- a/webapp/.eslintrc.js
+++ b/webapp/.eslintrc.js
@@ -2,6 +2,7 @@ module.exports = {
   extends: [
     'airbnb',
   ],
+  parser: 'babel-eslint',
   rules: {
     // Turn off some rules so that we can improve the code step by step
     'class-methods-use-this': 0,


### PR DESCRIPTION
* Use of optional chaining var?. is not directly support by eslint yet
* Add babel-eslint as parser