### PR TITLE
#385 limit initial dom objects rendered in jsonviewer

### DIFF
--- a/webapp/components/general/JsonViewer.js
+++ b/webapp/components/general/JsonViewer.js
@@ -117,6 +117,7 @@ const JsonViewer = (props) => {
         enableDelete={false}
         enableEdit={false}
         enableAdd={false}
+        collapsed={7}
       />
     </div>
   );


### PR DESCRIPTION
Since some objects in the JSON like `secs` and `secsLists` had a lot of items, the rendering was slowed down. So, I collapsed JSON objects/arrays with a depth of 7 or more to speed up the rendering and reduce lagging.