### PR TITLE
#518 fix: Fix "Save to json" ignored options

### DIFF
--- a/netpyne_ui/netpyne_geppetto.py
+++ b/netpyne_ui/netpyne_geppetto.py
@@ -259,7 +259,7 @@ class NetPyNEGeppetto:
                 netpyne_model = self.instantiateNetPyNEModel()
 
                 self.geppetto_model = self.model_interpreter.getGeppettoModel(netpyne_model)
-            
+
             simulations.run()
 
             if self.geppetto_model:
@@ -374,7 +374,7 @@ class NetPyNEGeppetto:
 
     def _prepare_batch_files(self, experiment: model.Experiment) -> str:
         """Creates template files and netpyne model files in the experiment folder.
-        
+
         Only for an experiment consisting of many trials.
 
         :param experiment: given experiment
@@ -599,7 +599,8 @@ class NetPyNEGeppetto:
                 if not args['netCells']:
                     sim.initialize(netParams=self.netParams, simConfig=self.simConfig)
                 sim.cfg.filename = args['fileName']
-                include = [el for el in specs.SimConfig().saveDataInclude if el in args.keys() and args[el]]
+                sim_config_data_include = specs.SimConfig().saveDataInclude
+                include = [el for el in sim_config_data_include if args.get(el, False)]
                 if args['netCells']: include += ['netPops']
                 sim.cfg.saveJson = True
                 sim.saveData(include)

--- a/webapp/components/topbar/dialogs/SaveFile.js
+++ b/webapp/components/topbar/dialogs/SaveFile.js
@@ -15,22 +15,22 @@ const saveOptions = [
   {
     label: 'High-level Network Parameters (netParams)',
     label2: 'Cell rules, connectivity rules, etc',
-    state: 'loadNetParams',
+    state: 'netParams',
   },
   {
     label: 'Simulation Configuration (simConfig)',
     label2: 'duration, recorded variables, etc',
-    state: 'loadSimCfg',
+    state: 'simConfig',
   },
   {
     label: 'Instantiated Network',
     label2: 'All cells, connections, etc',
-    state: 'loadNet',
+    state: 'netCells',
   },
   {
     label: 'Simulation Data',
     label2: 'Spikes, traces, etc',
-    state: 'loadSimData',
+    state: 'simData',
   },
 ];
 


### PR DESCRIPTION
Fixes #518 

This PR fixes the options that are passed to 

When I check/uncheck options, they options are well passed/removed from the `include` variable in Python that is passed to `sim.saveData(include)` (line 606 of this PR in `netpyne_geppetto.py`)
However, whether I uncheck all options or I check all of them, the produced json always includes this:

```json
"saveDataInclude": [
      "netParams",
      "netCells",
      "netPops",
      "simConfig",
      "simData"
    ],
```

Is it a normal behavior of the `saveData(...)` method in NetPyNE?