### PR TITLE
Feature/553

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,7 @@ COPY webapp/ .
 RUN yarn build-dev
 
 
-RUN mv node_modules/@metacell .
 RUN rm -Rf node_modules/*
-RUN mv @metacell node_modules
 
 ###
 FROM jupyter/base-notebook:hub-1.5.0

--- a/webapp/geppetto.ejs
+++ b/webapp/geppetto.ejs
@@ -19,8 +19,6 @@
 
     <!-- CSS -->
 	<link rel="stylesheet" href="geppetto/build/static/css/font-awesome.min.css"/>
-	<link rel="stylesheet" href="<%= cssPaths%>geppetto/node_modules/@metacell/geppetto-meta-client/style/css/codemirror.css"/>
-	<link rel="stylesheet" href="<%= cssPaths%>geppetto/node_modules/@metacell/geppetto-meta-client/style/css/lesser-dark.css"/>
 	<link rel="stylesheet" href="geppetto/build/static/css/gpt-icons.css"/>
 
 	<% if(htmlWebpackPlugin.options.GEPPETTO_CONFIGURATION.properties.icon.indexOf("http") !== -1){ %>

--- a/webapp/geppetto.ejs
+++ b/webapp/geppetto.ejs
@@ -18,17 +18,17 @@
 	<% } %>
 
     <!-- CSS -->
-	<link rel="stylesheet" href="<%= cssPaths%>geppetto/node_modules/@metacell/geppetto-meta-client/style/css/font-awesome.min.css"/>
+	<link rel="stylesheet" href="geppetto/build/static/css/font-awesome.min.css"/>
 	<link rel="stylesheet" href="<%= cssPaths%>geppetto/node_modules/@metacell/geppetto-meta-client/style/css/codemirror.css"/>
 	<link rel="stylesheet" href="<%= cssPaths%>geppetto/node_modules/@metacell/geppetto-meta-client/style/css/lesser-dark.css"/>
-	<link rel="stylesheet" href="<%= cssPaths%>geppetto/node_modules/@metacell/geppetto-meta-client/style/css/gpt-icons.css"/>
-	
+	<link rel="stylesheet" href="geppetto/build/static/css/gpt-icons.css"/>
+
 	<% if(htmlWebpackPlugin.options.GEPPETTO_CONFIGURATION.properties.icon.indexOf("http") !== -1){ %>
 		<link rel="icon" type="image/png" href="<%=htmlWebpackPlugin.options.GEPPETTO_CONFIGURATION.properties.icon%>"/>
 	<% } else{ %>
 	    <link rel="icon" type="image/png" href="<%= cssPaths%><%=htmlWebpackPlugin.options.GEPPETTO_CONFIGURATION.properties.icon%>"/>
 	<% } %>
-	    
+
 </head>
 <body style="margin: 0px">
 

--- a/webapp/webpack.config.js
+++ b/webapp/webpack.config.js
@@ -37,12 +37,10 @@ const availableExtensions = [
   {
     from: path.resolve(__dirname, geppettoClientPath, 'style/css/font-awesome.min.css'),
     to: 'static/css',
-    flatten: true,
   },
   {
     from: path.resolve(__dirname, geppettoClientPath, 'style/css/gpt-icons.css'),
     to: 'static/css',
-    flatten: true,
   },
   {
     from: path.resolve(__dirname, geppettoClientPath, 'static/*'),

--- a/webapp/webpack.config.js
+++ b/webapp/webpack.config.js
@@ -35,6 +35,16 @@ if (isWin) {
 
 const availableExtensions = [
   {
+    from: path.resolve(__dirname, geppettoClientPath, 'style/css/font-awesome.min.css'),
+    to: 'static/css',
+    flatten: true,
+  },
+  {
+    from: path.resolve(__dirname, geppettoClientPath, 'style/css/gpt-icons.css'),
+    to: 'static/css',
+    flatten: true,
+  },
+  {
     from: path.resolve(__dirname, geppettoClientPath, 'static/*'),
     to: 'static',
     flatten: true,
@@ -58,6 +68,7 @@ const availableExtensions = [
     from: path.resolve(__dirname, 'static'),
     to: 'static',
   },
+
 ];
 
 module.exports = function (env) {


### PR DESCRIPTION
Fixes #553 

The last two references in all the code to `node_modules/@metacell/...`, beside the icons, are those two css:

* `geppetto/node_modules/@metacell/geppetto-meta-client/style/css/codemirror.css`
* `geppetto/node_modules/@metacell/geppetto-meta-client/style/css/lesser-dark.css`

However, `codemirror.css` seems to be embedded in `utilities/custom.css` and `lesser-dark.css` seems like not existing anymore (the two calls result in a `404` when the app is launching). I removed them then.

I also removed the lines from the dockerfile that were referencing the mv/copy of the `@metacell` repository from the `Dockerfile`.