### PR TITLE
Fix missing icons

### DIFF
--- a/webapp/webpack.config.js
+++ b/webapp/webpack.config.js
@@ -35,6 +35,11 @@ if (isWin) {
 
 const availableExtensions = [
   {
+    from: path.resolve(__dirname, geppettoClientPath, 'style/fonts/*'),
+    to: 'static/fonts',
+    flatten: true,
+  },
+  {
     from: path.resolve(__dirname, geppettoClientPath, 'style/css/font-awesome.min.css'),
     to: 'static/css',
   },


### PR DESCRIPTION
Fixes the missing icons issue. The fonts were not properly copied from geppeto-meta/geppeto-client to the `fonts` folder. 

The issue didn't appear on my machine under brave/chromium for some reasons (with cleared cache and/or different profiles), but appeared using Firefox.