### PR TITLE
Feature/653

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,8 @@ RUN chown  $NB_UID .
 RUN chown -R $NB_UID workspace
 
 # Temp fixes for eeg plots
-RUN wget -P `pip show LFPykit | grep "Location:" | awk '{print $2"/lfpykit"}'` https://www.parralab.org/nyhead/sa_nyhead.mat
+# RUN wget -P $(pip show LFPykit | grep "Location:" | awk '{print $2"/lfpykit"}') https://www.parralab.org/nyhead/sa_nyhead.mat
+RUN wget --no-check-certificate -P /app/workspace https://www.parralab.org/nyhead/sa_nyhead.mat
 
 USER $NB_UID
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,8 +52,10 @@ RUN chown  $NB_UID .
 RUN chown -R $NB_UID workspace
 
 # Temp fixes for eeg plots
+# For lfpykit 0.4
 # RUN wget -P $(pip show LFPykit | grep "Location:" | awk '{print $2"/lfpykit"}') https://www.parralab.org/nyhead/sa_nyhead.mat
-RUN wget --no-check-certificate -P /app/workspace https://www.parralab.org/nyhead/sa_nyhead.mat
+# For lpfykit 0.5
+RUN wget --no-check-certificate -P ${FOLDER}/workspace https://www.parralab.org/nyhead/sa_nyhead.mat
 
 USER $NB_UID
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,6 +32,7 @@ jupyterlab==3.2.4
 jupyterthemes==0.20.0
 kiwisolver==1.2.0
 lesscpy==0.14.0
+lfpykit==0.5
 libNeuroML==0.2.50
 lxml==4.5.1
 Mako==1.1.0

--- a/webapp/redux/middleware/plotMiddleware.js
+++ b/webapp/redux/middleware/plotMiddleware.js
@@ -35,9 +35,10 @@ const plotFigure = async (plotId, plotMethod, plotType = false, uri = null, them
       new Promise((resolve, reject) => {
         setTimeout(() => {
           resolve(null);
-        }, 30000);
+        }, 2 * 60 * 1000); // Timeout set to 2 minutes, previously, 30000 (30s)
       })]);
 
+    // let response = await Utils.evalPythonMessage(NETPYNE_COMMANDS.plotFigure, [plotMethod, plotType, theme], false)
     console.log('Plot response received for', plotId);
     if (!response && !uri) { //png plots return null response but they provide a uri so they can be grabbed from the workspace
       return null;


### PR DESCRIPTION
Closes #653 

The main modification is where to download the `NYHead` model and set a timeout a little bit longer in case low resources are allocated to the computation pod. 
In `stage`, 1.5G of memory were necessary to get the EEG plotting working.