### PR TITLE
Show neuroml import error on failure, increase memory for jvm

### DIFF
--- a/netpyne_ui/helpers/neuroml.py
+++ b/netpyne_ui/helpers/neuroml.py
@@ -2,7 +2,9 @@ import os
 import sys
 import logging
 from netpyne.specs import simConfig
+from packaging import version
 
+import pyneuroml
 from pyneuroml import pynml
 from pyneuroml.lems import generate_lems_file_for_neuroml
 from pyneuroml.pynml import read_neuroml2_file
@@ -30,11 +32,21 @@ def convertLEMSSimulation(lemsFileName, compileMod=True):
             % fullLemsFileName
         )
 
-        result = pynml.run_lems_with_jneuroml_netpyne(
-            lemsFileName, only_generate_json=True, exit_on_fail=False)
-        
-        if result == False:
-            raise Exception("Error loading lems file")
+        # feature to return output added in 1.0.9
+        if version.parse(pyneuroml.__version__) >= version.parse("1.0.9"):
+            result, output_msg = pynml.run_lems_with_jneuroml_netpyne(
+                lemsFileName, only_generate_json=True, exit_on_fail=False,
+                return_string=True)
+            
+            if result is False:
+                raise Exception(f"Error loading lems file: {output_msg}")
+        else:
+            result = pynml.run_lems_with_jneuroml_netpyne(
+                lemsFileName, only_generate_json=True, exit_on_fail=False)
+            
+            if result is False:
+                raise Exception("Error loading lems file")
+
         lems = pynml.read_lems_file(lemsFileName)
 
         np_json_fname = fullLemsFileName.replace('.xml','_netpyne_data.json')

--- a/netpyne_ui/helpers/neuroml.py
+++ b/netpyne_ui/helpers/neuroml.py
@@ -36,13 +36,14 @@ def convertLEMSSimulation(lemsFileName, compileMod=True):
         if version.parse(pyneuroml.__version__) >= version.parse("1.0.9"):
             result, output_msg = pynml.run_lems_with_jneuroml_netpyne(
                 lemsFileName, only_generate_json=True, exit_on_fail=False,
-                return_string=True)
+                return_string=True, max_memory="1G")
             
             if result is False:
                 raise Exception(f"Error loading lems file: {output_msg}")
         else:
             result = pynml.run_lems_with_jneuroml_netpyne(
-                lemsFileName, only_generate_json=True, exit_on_fail=False)
+                lemsFileName, only_generate_json=True, exit_on_fail=False,
+                max_memory="1G")
             
             if result is False:
                 raise Exception("Error loading lems file")

--- a/netpyne_ui/helpers/neuroml.py
+++ b/netpyne_ui/helpers/neuroml.py
@@ -15,16 +15,18 @@ from netpyne_ui.mod_utils import loadModMechFiles
 def convertLEMSSimulation(lemsFileName, compileMod=True):
     """Converts a LEMS Simulation file
 
-    Converts a LEMS Simulation file (https://docs.neuroml.org/Userdocs/LEMSSimulation.html)
-    pointing to a NeuroML 2 file into the equivalent in NetPyNE
+    Converts a LEMS Simulation file
+    (https://docs.neuroml.org/Userdocs/LEMSSimulation.html) pointing to a
+    NeuroML 2 file into the equivalent in NetPyNE
+
     Returns:
         simConfig, netParams for the model in NetPyNE
     """
     current_path = os.getcwd()
     try:
-        
+
         fullLemsFileName = os.path.abspath(lemsFileName)
-        tmp_path = os.path.dirname(fullLemsFileName) 
+        tmp_path = os.path.dirname(fullLemsFileName)
         if tmp_path:
             os.chdir(tmp_path)
         logging.info(
@@ -37,33 +39,31 @@ def convertLEMSSimulation(lemsFileName, compileMod=True):
             result, output_msg = pynml.run_lems_with_jneuroml_netpyne(
                 lemsFileName, only_generate_json=True, exit_on_fail=False,
                 return_string=True, max_memory="1G")
-            
+
             if result is False:
                 raise Exception(f"Error loading lems file: {output_msg}")
         else:
             result = pynml.run_lems_with_jneuroml_netpyne(
                 lemsFileName, only_generate_json=True, exit_on_fail=False,
                 max_memory="1G")
-            
+
             if result is False:
                 raise Exception("Error loading lems file")
 
         lems = pynml.read_lems_file(lemsFileName)
 
         np_json_fname = fullLemsFileName.replace('.xml','_netpyne_data.json')
-    
+
         return np_json_fname
     finally:
         os.chdir(current_path)
 
 
-
-
 def convertNeuroML2(nml2FileName,  compileMod=True):
     """Loads a NeuroML 2 file into NetPyNE
     Loads a NeuroML 2 file into NetPyNE by creating a new LEMS Simulation
-    file (https://docs.neuroml.org/Userdocs/LEMSSimulation.html) and using jNeuroML
-    to convert it.
+    file (https://docs.neuroml.org/Userdocs/LEMSSimulation.html) and using
+    jNeuroML to convert it.
 
     Returns:
         simConfig, netParams for the model in NetPyNE
@@ -71,12 +71,11 @@ def convertNeuroML2(nml2FileName,  compileMod=True):
     current_path = os.getcwd()
     try:
         fullNmlFileName = os.path.abspath(nml2FileName)
-        work_path = os.path.dirname(fullNmlFileName) 
+        work_path = os.path.dirname(fullNmlFileName)
         if not os.path.exists(work_path):
             os.makedirs(work_path)
         os.chdir(work_path)
         sys.path.append(work_path)
-        
 
         logging.info(
                 "Importing NeuroML 2 network from: %s"


### PR DESCRIPTION
Requires pyneuroml > 1.0.9 (not yet released).

Also increases memory available to jvm---required when converting larger neuroml models