### PR TITLE
Widget Order

### DIFF
--- a/webapp/components/drawer/Drawer.js
+++ b/webapp/components/drawer/Drawer.js
@@ -138,7 +138,9 @@ const DrawerList = ({
   function getMenu () {
     const [modelDrawerItems, toolsDrawerItems] = [[], []];
     // eslint-disable-next-line array-callback-return
-    Object.values(widgets).sort((w1, w2) => w1.pos - w2.pos).filter((widget) => {
+    Object.values(widgets)
+    //.sort((w1, w2) => w1.pos - w2.pos)
+    .filter((widget) => {
       widget.specification !== TOOLS_LIST
         ? modelDrawerItems.push(widget) : toolsDrawerItems.push(widget);
     });


### PR DESCRIPTION
**Description** 

As described in https://metacell.atlassian.net/browse/NETPYNE-208 the left bar icons order is affected after running simulations and creating plots. 

**Problem** 

The middleware switchLayoutAction function interceeds with the reducer, this is an anti pattern and bad design as widgets shouldn't be controlled in the middleware while actions are fired in parallel from the reducer where the redux state is affected, producing the ordering side effect.

There seems to be an other issue with the LayoutManager itself as the widget positions came back altered, probably because of the previously mentioned side effect, there are positions with the same index. 

**Solution**

in [Drawer.js](https://github.com/MetaCell/NetPyNE-UI/blob/development/webapp/components/drawer/Drawer.js) the sort call getMenu has been commented out. This is just a paleative as the inner problem remains and could have side effects. Fixing the real issue could take several hours and involve de App, Geppetto and the Layout Manager so this is as far as we can go given that release date dued. 